### PR TITLE
Fix weird issue with IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flexbox-layout",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Simple flexible layouts for IE9+",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function addStyleString(str) {
 }
 
 const flexGrowParentRules = '{ display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }';
-const flexGrowChildRules = '{ -webkit-box-flex: 1; -webkit-flex: 1; flex: 1; position: relative; -ms-flex: 1 0 auto;}';
+const flexGrowChildRules = '{ -webkit-box-flex: 1; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}';
 
 const staticGrowChildRules = '{ display: block !important; width: 100%; height: 100%; }';
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function addStyleString(str) {
 }
 
 const flexGrowParentRules = '{ display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }';
-const flexGrowChildRules = '{ -webkit-box-flex: 1; -webkit-flex: 1; -ms-flex: 1; flex: 1; position: relative; }';
+const flexGrowChildRules = '{ -webkit-box-flex: 1; -webkit-flex: 1; flex: 1; position: relative; -ms-flex: 1 0 auto;}';
 
 const staticGrowChildRules = '{ display: block !important; width: 100%; height: 100%; }';
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function addStyleString(str) {
 }
 
 const flexGrowParentRules = '{ display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }';
-const flexGrowChildRules = '{ -webkit-box-flex: 1; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}';
+const flexGrowChildRules = '{ -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}';
 
 const staticGrowChildRules = '{ display: block !important; width: 100%; height: 100%; }';
 


### PR DESCRIPTION
This really small change fix a weird issue with IE11. The basic concept of the change is here: https://css-tricks.com/snippets/css/a-guide-to-flexbox/#comment-1592128

Basically with -ms-flex: 1 the result is:

![without_1_0_auto](https://cloud.githubusercontent.com/assets/128563/8737510/bd579d90-2bd7-11e5-84b9-ee34346cd6d9.png)

and with -ms-flex: 1 0 auto the result is:

![with_1_0_auto](https://cloud.githubusercontent.com/assets/128563/8737517/c6ae0302-2bd7-11e5-87f6-85e3139df707.png)

my first approach was to respect the order (first the prefixed attributes, then the proper one), but I found that the only way of making IE11 process the -ms-flex:1 0 auto is adding it at the end.

@rafaelchiti @byronmwong Please review this when you have a chance.
