### PR TITLE
Revert "better EXPAND_CHILD behavior"

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,11 +1,11 @@
 .rflGrowChildFlex { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > * { -webkit-box-flex: 1 1 0; -webkit-flex: 1 1 0; -ms-flex: 1 1 0; flex: 1 1 0; position: relative;}
+.rflGrowChildFlex > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: 1 1 0; -webkit-flex: 1 1 0; -ms-flex: 1 1 0; flex: 1 1 0; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: 1 1 0; -webkit-flex: 1 1 0; -ms-flex: 1 1 0; flex: 1 1 0; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
 
 
 .rflGrowChildStatic > * { display: block !important; width: 100%; height: 100%; }


### PR DESCRIPTION
Go back to old `EXPAND_CHILD` flex since it avoids IE 10/11 flex shorthand bug

This reverts commit 911bd83cfde0c3d265c5126161f32f48d397f0b3.
