### PR TITLE
Fix width issue when using "strech" with a paragraph

### DIFF
--- a/examples/two-columns/app.jsx
+++ b/examples/two-columns/app.jsx
@@ -1,0 +1,81 @@
+import _ from 'lodash';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+  VLayout,
+  HLayout,
+  HLayoutItem
+} from 'react-flexbox-layout';
+
+import 'react-flexbox-layout/styles.css';
+
+class DummyNode extends React.Component {
+  render() {
+    let style = {background: '#aaa'};
+    _.extend(style, this.props.style);
+
+    return (
+      <div {...this.props} style={style} />
+    );
+  }
+}
+
+const cardStyle = {
+  width: '33.333333333333336%',
+  verticalAlign: 'top',
+  display: 'inline-block',
+  padding: '5px'
+};
+
+const contentStyle = {
+  width: '690px',
+  minHeight: '500px',
+  padding: '20px',
+  boxShadow: 'rgba(0,0,0,.4) 0 3px 6px',
+  backgroundColor: 'white'
+};
+
+ReactDOM.render((
+  <div style={{ width: '60%', marginLeft: '10%', marginTop: '5%' }}>
+    <VLayout>
+      <div style={{ fontSize: '48px', paddingLeft: '15px' }}>
+        TWO COLUMNS
+      </div>
+      <HLayout gutter={0} justifyItems='left' alignItems='top'>
+        <HLayoutItem style={{ widht: '230px', height: '200px' }}>
+          <DummyNode style={{padding: 10}}>Left</DummyNode>
+        </HLayoutItem>
+
+        <HLayoutItem align='stretch' style={contentStyle}>
+          <div style={{  minWidth: 0 }}>
+            <h3>Central Column</h3>
+            <p style={{ fontSize: '16px', fontWeight: 200, lineHeight: '19.7px' }}>
+              Because the size of this paragraph is longer that the container, flex-shrink cannot calculate the width beforehand and make a mess with
+              the layout. To prevent problems with this, we change `flex: 1 0 auto` to `flex: auto`.
+            </p>
+            <div>
+              <div style={cardStyle}>
+                <DummyNode>One</DummyNode>
+              </div>
+              <div style={cardStyle}>
+                <DummyNode>Two</DummyNode>
+              </div>
+              <div style={cardStyle}>
+                <DummyNode>Three</DummyNode>
+              </div>
+              <div style={cardStyle}>
+                <DummyNode>Four</DummyNode>
+              </div>
+              <div style={cardStyle}>
+                <DummyNode>Five</DummyNode>
+              </div>
+              <div style={cardStyle}>
+                <DummyNode>Six</DummyNode>
+              </div>
+            </div>
+          </div>
+        </HLayoutItem>
+      </HLayout>
+    </VLayout>
+  </div>
+), document.getElementById("example"));

--- a/examples/two-columns/index.html
+++ b/examples/two-columns/index.html
@@ -1,0 +1,18 @@
+<html style="height: 100%; position: relative;">
+<head>
+<link rel="stylesheet" href="/shared.css" />
+<link rel="stylesheet" href="/__build__/shared.css" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+<style>
+* { box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="example">
+</div>
+<script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.7/es5-shim.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.7/es5-sham.min.js"></script>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/two-columns.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "babel-node test/server_side-test",
     "build": "rm -rf lib && babel ./src -d lib && cp src/styles.css lib/",
     "watch": "babel ./src --watch -d lib",
-    "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples --inline",
+    "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples --inline --host 0.0.0.0",
     "prepublish": "npm run build"
   },
   "repository": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,11 +1,11 @@
 .rflGrowChildFlex { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
+.rflGrowChildFlex > * { -webkit-box-flex: 1 1 auto; -webkit-flex: 1 1 auto; -ms-flex: 1 1 auto; flex: 1 1 auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: 1 1 auto; -webkit-flex: 1 1 auto; -ms-flex: 1 1 auto; flex: 1 1 auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: 1 1 auto; -webkit-flex: 1 1 auto; -ms-flex: 1 1 auto; flex: 1 1 auto; position: relative;}
 
 
 .rflGrowChildStatic > * { display: block !important; width: 100%; height: 100%; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,11 +1,11 @@
 .rflGrowChildFlex { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
+.rflGrowChildFlex > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
 
 .rflGrowChildFlex > .rflExpandChild > .rflExpandChild { display: -webkit-box !important; display: -webkit-flex !important; display: -ms-flexbox !important; display: flex !important; }
-.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: 1 0 auto; -webkit-flex: 1 0 auto; -ms-flex: 1 0 auto; flex: 1 0 auto; position: relative;}
+.rflGrowChildFlex > .rflExpandChild > .rflExpandChild > * { -webkit-box-flex: auto; -webkit-flex: auto; -ms-flex: 1 1 auto; flex: auto; position: relative;}
 
 
 .rflGrowChildStatic > * { display: block !important; width: 100%; height: 100%; }


### PR DESCRIPTION
This issue was causing problems with the calculation of the width as seen here:

![screen shot 2016-06-17 at 11 35 39 am](https://cloud.githubusercontent.com/assets/128563/16154629/0e5e33d0-3482-11e6-8c40-277067cc24c0.png)

I understand the issue was because using `flex: 1 0 auto` calculates wrong the "width" (because `0` don't force the children to shrinkg), and given the paragraph is auto-sized it mades the parent element calculates the width as `max-content` (the maximum width of the paragraph).

 [How flex-box calculates size](https://drafts.csswg.org/css-flexbox/#algo-main-item)

Using `flex: auto` (except for IE 10 that uses `flex: 1 1 auto` [Read more about the API differences [here](https://msdn.microsoft.com/en-us/library/hh673531%28v=vs.85%29.aspx) and [here](https://developer.mozilla.org/es/docs/Web/CSS/flex)]) fix this issue as shown here:

![screen shot 2016-06-17 at 11 49 21 am](https://cloud.githubusercontent.com/assets/128563/16154978/a2da30b2-3483-11e6-895c-f2f2fefcbfd5.png)
