### PR TITLE
fix: clean props sent to children

### DIFF
--- a/src/horizontal.jsx
+++ b/src/horizontal.jsx
@@ -2,7 +2,7 @@ import extend from 'lodash/extend';
 import React from 'react';
 import classNames from 'classnames';
 import HLayoutItem from './horizontal_item';
-import {HLayoutPropTypes, HLayoutDefaultPropTypes} from './prop_types';
+import {HLayoutPropTypes, HLayoutDefaultPropTypes, cleanProps} from './prop_types';
 import {
   getHGutterSizes, makeHLayoutItemChildProps,
   mapNonEmpty, normalizeJustify
@@ -34,7 +34,7 @@ export default function(defaultGutter, gutterMultiplier, defaultGutterUnit) {
       return (
         <div
           data-display-name="HLayout"
-          {...this.props}
+          {...cleanProps(this.props)}
           className={classNames(this.props.className, this._getContainerClassName())}
           style={extend(this._getContainerStyles(), this.props.style)}
         >

--- a/src/horizontal_ie9.jsx
+++ b/src/horizontal_ie9.jsx
@@ -5,7 +5,7 @@ import sum from 'lodash/sum';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import HLayoutItemIE9 from './horizontal_item_ie9';
-import {HLayoutPropTypes, HLayoutDefaultPropTypes} from './prop_types';
+import {HLayoutPropTypes, HLayoutDefaultPropTypes, cleanProps} from './prop_types';
 import {
   getHGutterSizes, makeHLayoutItemChildProps,
   mapNonEmpty, countNonEmpty,
@@ -46,7 +46,7 @@ export default function(defaultGutter, gutterMultiplier, defaultGutterUnit) {
       return (
         <div ref="horizontal"
           data-display-name="HLayout"
-          {...this.props}
+          {...cleanProps(this.props)}
           style={extend(this._getLayoutStyles(), this.props.style)}
         >
           {children}

--- a/src/horizontal_item.jsx
+++ b/src/horizontal_item.jsx
@@ -1,7 +1,7 @@
 import extend from 'lodash/extend';
 import React from 'react';
 import classNames from 'classnames';
-import {HLayoutItemPropTypes} from './prop_types';
+import {HLayoutItemPropTypes, cleanProps} from './prop_types';
 import {normalizeAlign} from './util';
 import {prefixFlexProp} from './vendors_helper';
 
@@ -13,7 +13,7 @@ export default class HLayoutItem extends React.Component {
     };
 
     return (
-      <div {...this.props} {...props}
+      <div {...cleanProps(this.props)} {...props}
         className={classNames(this.props.className, this._getClassName())}
       >
         {this.props.children}

--- a/src/horizontal_item_ie9.jsx
+++ b/src/horizontal_item_ie9.jsx
@@ -2,7 +2,7 @@ import extend from 'lodash/extend';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {didDefineWidth} from './util';
-import {HLayoutItemPropTypes} from './prop_types';
+import {HLayoutItemPropTypes, cleanProps} from './prop_types';
 
 
 export default class HLayoutItemIE9 extends React.Component {
@@ -16,7 +16,7 @@ export default class HLayoutItemIE9 extends React.Component {
       return (
         <div ref="inner"
           data-display-name="HLayoutItem"
-          {...this.props}
+          {...cleanProps(this.props)}
           className={this.props.className ? this.props.className + ' ' + this._getClassname() : this._getClassname()}
           style={extend(this._getInnerStyles(), this._getWrapperStyles(), this.props.style)}
         >
@@ -24,8 +24,9 @@ export default class HLayoutItemIE9 extends React.Component {
         </div>
       );
     } else {
+
       return (
-        <div data-display-name="HLayoutItemWrapper" {...this.props} style={extend(this._getWrapperStyles())}>
+        <div data-display-name="HLayoutItemWrapper" {...cleanProps(this.props)} style={extend(this._getWrapperStyles())}>
           <div style={{display: 'inline-block', verticalAlign: 'middle', width: 0, overflow: 'hidden'}}>a</div>
           <div ref="inner"
             data-display-name="HLayoutItem"

--- a/src/prop_types.js
+++ b/src/prop_types.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 
 function layoutItemChildrenChecker(props, propName, componentName) {
   if (React.Children.count(props[propName]) > 1) {
@@ -151,19 +152,15 @@ const layoutItemDangerousStyles = everythingDangerousStyles.concat([
   "position", "margin", "marginTop", "marginBottom", "marginLeft", "marginRight"
 ]);
 
+const proprietaryProps = _.keys(_.assign({},
+  HLayoutPropTypes,
+  HLayoutDefaultPropTypes,
+  HLayoutItemPropTypes,
+  VLayoutPropTypes,
+  VLayoutDefaultPropTypes,
+  VLayoutItemPropTypes
+));
 
 export const cleanProps = function (props) {
-  const proprietaryProps = Object.keys(Object.assign({},
-    HLayoutPropTypes,
-    HLayoutDefaultPropTypes,
-    HLayoutItemPropTypes,
-    VLayoutPropTypes,
-    VLayoutDefaultPropTypes,
-    VLayoutItemPropTypes
-  ));
-  let safeProps = Object.assign({}, props);
-  for (let k in proprietaryProps) {
-    delete safeProps[proprietaryProps[k]];
-  }
-  return safeProps;
+  return _.omit(props, proprietaryProps);
 };

--- a/src/prop_types.js
+++ b/src/prop_types.js
@@ -150,3 +150,20 @@ const layoutDangerousStyles = everythingDangerousStyles;
 const layoutItemDangerousStyles = everythingDangerousStyles.concat([
   "position", "margin", "marginTop", "marginBottom", "marginLeft", "marginRight"
 ]);
+
+
+export const cleanProps = function (props) {
+  const proprietaryProps = Object.keys(Object.assign({},
+    HLayoutPropTypes,
+    HLayoutDefaultPropTypes,
+    HLayoutItemPropTypes,
+    VLayoutPropTypes,
+    VLayoutDefaultPropTypes,
+    VLayoutItemPropTypes
+  ));
+  let safeProps = Object.assign({}, props);
+  for (let k in proprietaryProps) {
+    delete safeProps[proprietaryProps[k]];
+  }
+  return safeProps;
+};

--- a/src/vertical.jsx
+++ b/src/vertical.jsx
@@ -2,7 +2,7 @@ import extend from 'lodash/extend';
 import React from 'react';
 import classNames from 'classnames';
 import VLayoutItem from './vertical_item';
-import {VLayoutPropTypes, VLayoutDefaultPropTypes} from './prop_types';
+import {VLayoutPropTypes, VLayoutDefaultPropTypes, cleanProps} from './prop_types';
 import {
   getVGutterSizes, makeVLayoutItemChildProps,
   mapNonEmpty, normalizeAlign
@@ -34,7 +34,7 @@ export default function(defaultGutter, gutterMultiplier, defaultGutterUnit) {
       return (
         <div
           data-display-name="VLayout"
-          {...this.props}
+          {...cleanProps(this.props)}
           className={classNames(this.props.className, this._getContainerClassName())}
           style={extend(this._getContainerStyles(), this.props.style)}
         >

--- a/src/vertical_ie9.jsx
+++ b/src/vertical_ie9.jsx
@@ -5,7 +5,7 @@ import sum from 'lodash/sum';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import VLayoutItemIE9 from './vertical_item_ie9';
-import {VLayoutPropTypes, VLayoutDefaultPropTypes} from './prop_types';
+import {VLayoutPropTypes, VLayoutDefaultPropTypes, cleanProps} from './prop_types';
 import {
   getVGutterSizes, makeVLayoutItemChildProps,
   forEachNonEmpty, mapNonEmpty, countNonEmpty,
@@ -42,9 +42,10 @@ export default function(defaultGutter, gutterMultiplier, defaultGutterUnit) {
         return this._buildChild(child, index, this.gutterSizes);
       });
 
+
       return (
         <div ref="wrapper" data-display-name="VLayoutWrapper"
-          {...this.props}
+          {...cleanProps(this.props)}
           style={extend(this._getLayoutWrapperStyles(), this.props.style)}
         >
           <div ref="container" data-display-name="VLayout"

--- a/src/vertical_item.jsx
+++ b/src/vertical_item.jsx
@@ -1,7 +1,7 @@
 import extend from 'lodash/extend';
 import React from 'react';
 import classNames from 'classnames';
-import {VLayoutItemPropTypes} from './prop_types';
+import {VLayoutItemPropTypes, cleanProps} from './prop_types';
 import {prefixFlexProp} from './vendors_helper';
 import {normalizeJustify} from './util';
 
@@ -10,7 +10,7 @@ export default class VLayoutItem extends React.Component {
     return (
       <div
         data-display-name="VLayoutItem"
-        {...this.props}
+        {...cleanProps(this.props)}
         className={classNames(this.props.className, this._getClassName())}
         style={extend(this._getStyles(), this.props.style)}
       >

--- a/src/vertical_item_ie9.jsx
+++ b/src/vertical_item_ie9.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import extend from 'lodash/extend';
 import {didDefineWidth, didDefineHeight} from './util';
-import {VLayoutItemPropTypes} from './prop_types';
+import {VLayoutItemPropTypes, cleanProps} from './prop_types';
 
 
 export default class VLayoutItemIE9 extends React.Component {
@@ -16,7 +16,7 @@ export default class VLayoutItemIE9 extends React.Component {
     return (
       <div
         data-display-name="VLayoutItemWrapper"
-        {...this.props}
+        {...cleanProps(this.props)}
         style={extend(this._getItemWrapperStyles(), this.props.style)}
       >
         <div ref="inner" style={this._getItemStyles()}


### PR DESCRIPTION
remove proprietary props so they are not sent to children because this
causes a warning.

fixes #27
