### PR TITLE
Removes unnecessary important in VerticalLayout_IE9

### DIFF
--- a/src/vertical_ie9.jsx
+++ b/src/vertical_ie9.jsx
@@ -158,9 +158,7 @@ export default function(defaultGutter, gutterMultiplier, defaultGutterUnit) {
       if (this._isFlexboxLayout()) {
         styles.display = 'block';
       } else {
-        // NOTE: use !important override rflGrowChildStatic className, which uses display: block !important
-        // to override children who use display: inline-block
-        styles.display = 'table !important';
+        styles.display = 'table';
         styles.tableLayout = 'fixed';
       }
 


### PR DESCRIPTION
Fixes issue for IE9 as style.display = 'table !important' was omitted when passing styles as props due to the fact it's an inline style so it takes precedence nevertheless without the need of important.